### PR TITLE
shade JSQLParser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,8 @@ val bundle = (project in file("bundle"))
     assembleArtifact in assemblyPackageScala := false,
     assemblyShadeRules in assembly := Seq(
       ShadeRule.zap("**module-info").inAll,
-      ShadeRule.rename("net.bytebuddy.agent.**" -> "kamon.lib.@0").inAll
+      ShadeRule.rename("net.bytebuddy.agent.**" -> "kamon.lib.@0").inAll,
+      ShadeRule.rename("net.sf.jsqlparser.**" -> "kamon.lib.@0").inAll
     ),
     assemblyMergeStrategy in assembly := {
       case "reference.conf" => MergeStrategy.concat


### PR DESCRIPTION
@ivantopo can we shade JSQLParser library? this will let me use an updated version.
If this is not possible can you tell how I could avoid using the kamon-bundle and just import individual kamon libraries